### PR TITLE
Add Halium/halium-devices

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -237,4 +237,5 @@
   <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="refs/heads/halium-7.1" />
   <project path="halium/hybris-boot" name="Halium/hybris-boot" remote="hal" revision="refs/heads/master" />
   <project path="halium/audioflingerglue" name="Halium/audioflingerglue" remote="hal" />
+  <project path="halium/devices" name="Halium/halium-devices" remote="hal" />
 </manifest>


### PR DESCRIPTION
Allows to checkout existing manifests from http://github.com/halium/halium-devices by using `./halium/devices/setup $CODENAME`