### PR TITLE
Add commonly used repos to default.xml

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -37,6 +37,9 @@
   <project path="development" name="android_development" remote="los" />
 
   <project path="device/google/contexthub" name="device/google/contexthub" groups="device,marlin,pdk" remote="aosp" />
+  <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" groups="qcom" remote="los" />
+  <project path="device/qcom/common" name="android_device_qcom_common" groups="qcom" remote="los" />
+  <project path="vendor/qcom/opensource/cryptfs_hw" name="android_vendor_qcom_opensource_cryptfs_hw" groups="qcom" remote="los" />
   <project path="external/boringssl" name="android_external_boringssl" groups="pdk" remote="los" />
   <project path="external/bson" name="android_external_bson" remote="los" />
   <project path="external/busybox" name="Halium/android_external_busybox" groups="pdk" remote="hal" />
@@ -53,6 +56,7 @@
   <project path="external/fec" name="platform/external/fec" groups="pdk" remote="aosp" />
   <project path="external/squashfs-tools" name="platform/external/squashfs-tools" groups="pdk" remote="aosp" />
   <project path="external/aac" name="android_external_aac" remote="los" groups="pdk" />
+  <project path="external/ant-wireless/antradio-library" name="android_external_ant-wireless_antradio-library" remote="los" />
   <project path="external/bison" name="platform/external/bison" groups="pdk" />
   <project path="external/bzip2" name="android_external_bzip2" remote="los" groups="pdk" />
   <project path="external/compiler-rt" name="Halium/android_external_compiler-rt" remote="hal" groups="pdk" />
@@ -113,6 +117,7 @@
   <project path="external/sonivox" name="platform/external/sonivox" groups="pdk" />
   <project path="external/speex" name="platform/external/speex" groups="pdk" />
   <project path="external/sqlite" name="platform/external/sqlite" groups="pdk" />
+  <project path="external/stlport" name="android_external_stlport" remote="los" />
   <project path="external/strace" name="platform/external/strace" groups="pdk-cw-fs" />
   <project path="external/sonic" name="platform/external/sonic" groups="pdk" remote="aosp" />
   <project path="external/tinyalsa" name="android_external_tinyalsa" groups="pdk" remote="los" />


### PR DESCRIPTION
Some of them like android_device_qcom_sepolicy and android_device_qcom_common are used commonly in the majority of projects, so make sense to sync them as default. Others are small, so don't cause much overhead either.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>