### PR TITLE
Add libcore

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -210,6 +210,7 @@
   <project path="hardware/ril-caf" name="android_hardware_ril" groups="pdk" revision="cm-14.1-caf" remote="los"  />
 
   <project path="libnativehelper" name="platform/libnativehelper" groups="pdk" />
+  <project path="libcore" name="android_libcore" groups="pdk" remote="hal" />
   <project path="prebuilts/clang/linux-x86/host/3.6" name="platform/prebuilts/clang/linux-x86/host/3.6" groups="pdk,linux" clone-depth="1" remote="aosp" />
   <project path="prebuilts/clang/host/linux-x86" name="platform/prebuilts/clang/host/linux-x86" groups="pdk" clone-depth="1" remote="aosp" />
   <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" name="android_prebuilts_gcc_linux-x86_aarch64_aarch64-linux-android-4.9" groups="pdk,linux,arm" remote="los" clone-depth="1" />


### PR DESCRIPTION
it seems new versions of frameworks_native have libgui which depends on
the libnativeloader and hence libcore.

It have java stuff removed

Change-Id: I63c6ba86c2341e4e4cb08f2d36d20a952a99dcdf