### PR TITLE
Add halium-boot to 7.1 manifest

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -247,5 +247,6 @@
   <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="refs/heads/halium-7.1" />
   <project path="halium/hybris-boot" name="Halium/hybris-boot" remote="hal" revision="refs/heads/master" />
   <project path="halium/audioflingerglue" name="Halium/audioflingerglue" remote="hal" />
+  <project path="halium/halium-boot" name="Halium/halium-boot" remote="hal" revision="master" />
   <project path="halium/devices" name="Halium/halium-devices" remote="hal" />
 </manifest>


### PR DESCRIPTION
This adds halium-boot to the 7.1 manifest.