### PR TITLE
default.xml: Set sync-c value and increase sync-j value

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -20,7 +20,8 @@
 	revision="refs/heads/cm-14.1" />
 
   <default remote="aosp"
-           sync-j="6" />
+           sync-j="8"
+           sync-c="true" />
 
   <project path="abi/cpp" name="platform/abi/cpp" groups="pdk" remote="aosp" />
 


### PR DESCRIPTION
sync-c will make sure only indicated branch in manifest will be downloaded. Will save on download space.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>