### PR TITLE
Remove remote code-review.phablet.ubuntu.com

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
     <remote name="phablet"
-            fetch="https://code-review.phablet.ubuntu.com"
-            review="https://code-review.phablet.ubuntu.com"
+            fetch="http://github.com/ubports-android"
+            review="http://review.ubports.com"
             revision="refs/tags/android-5.1.1_r5" />
 
     <remote name="aosp"
@@ -46,87 +46,87 @@
 
     <project path="development" name="ubports/android_development" remote="ubp" />
 
-    <project path="external/aac" name="aosp/platform/external/aac" groups="pdk" />
+    <project path="external/aac" name="aosp_platform_external_aac" groups="pdk" />
     <project path="external/audioflingerglue" name="ubports/audioflingerglue" remote="ubp" />
-    <project path="external/bison" name="aosp/platform/external/bison" groups="pdk" />
+    <project path="external/bison" name="aosp_platform_external_bison" groups="pdk" />
     <project path="external/bson" name="android_external_bson" remote="cm" />
-    <project path="external/busybox" name="CyanogenMod/android_external_busybox" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
-    <project path="external/bzip2" name="aosp/platform/external/bzip2" groups="pdk" />
-    <project path="external/checkpolicy" name="aosp/platform/external/checkpolicy" groups="pdk" />
-    <project path="external/compiler-rt" name="aosp/platform/external/compiler-rt" groups="pdk" />
+    <project path="external/busybox" name="CyanogenMod_android_external_busybox" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
+    <project path="external/bzip2" name="aosp_platform_external_bzip2" groups="pdk" />
+    <project path="external/checkpolicy" name="aosp_platform_external_checkpolicy" groups="pdk" />
+    <project path="external/compiler-rt" name="aosp_platform_external_compiler-rt" groups="pdk" />
     <project path="external/connectivity" name="android_external_connectivity" remote="cm" />
     <project path="external/e2fsprogs" name="ubports/android_external_e2fsprogs" groups="pdk" remote="ubp" />
-    <project path="external/expat" name="aosp/platform/external/expat" groups="pdk" />
+    <project path="external/expat" name="aosp_platform_external_expat" groups="pdk" />
     <project path="external/exfat" name="android_external_exfat" groups="pdk" remote="cm" />
     <project path="external/f2fs-tools" name="android_external_f2fs-tools" groups="pdk" remote="cm" />
     <project path="external/ffmpeg" name="android_external_ffmpeg" remote="cm" />
     <project path="external/flac" name="android_external_flac" groups="pdk" remote="cm" />
-    <project path="external/freetype" name="aosp/platform/external/freetype" groups="pdk" />
+    <project path="external/freetype" name="aosp_platform_external_freetype" groups="pdk" />
     <project path="external/fsck_msdos" name="ubports/android_external_fsck_msdos" groups="pdk-cw-fs" remote="ubp" />
     <project path="external/fuse" name="android_external_fuse" remote="cm" />
-    <project path="external/gcc-demangle" name="aosp/platform/external/gcc-demangle" groups="pdk" />
-    <project path="external/genext2fs" name="aosp/platform/external/genext2fs" groups="pdk-cw-fs" />
-    <project path="external/giflib" name="aosp/platform/external/giflib" groups="pdk-cw-fs" />
-    <project path="external/gpg" name="aosp/platform/external/gpg" revision="refs/heads/master" />
-    <project path="external/gtest" name="aosp/platform/external/gtest" groups="pdk" />
-    <project path="external/harfbuzz_ng" name="aosp/platform/external/harfbuzz_ng" groups="pdk-cw-fs" />
+    <project path="external/gcc-demangle" name="aosp_platform_external_gcc-demangle" groups="pdk" />
+    <project path="external/genext2fs" name="aosp_platform_external_genext2fs" groups="pdk-cw-fs" />
+    <project path="external/giflib" name="aosp_platform_external_giflib" groups="pdk-cw-fs" />
+    <project path="external/gpg" name="aosp_platform_external_gpg" revision="refs/heads/master" />
+    <project path="external/gtest" name="aosp_platform_external_gtest" groups="pdk" />
+    <project path="external/harfbuzz_ng" name="aosp_platform_external_harfbuzz_ng" groups="pdk-cw-fs" />
     <project path="external/icu" name="android_external_icu" groups="pdk" remote="cm" />
     <project path="external/iptables" name="android_external_iptables" groups="pdk" remote="cm" />
     <project path="external/iproute2" name="android_external_iproute2" groups="pdk" remote="cm" />  
-    <project path="external/jemalloc" name="aosp/platform/external/jemalloc" groups="pdk,flo" />
-    <project path="external/jhead" name="aosp/platform/external/jhead" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
+    <project path="external/jemalloc" name="aosp_platform_external_jemalloc" groups="pdk,flo" />
+    <project path="external/jhead" name="aosp_platform_external_jhead" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
     <project path="external/jpeg" name="android_external_jpeg" groups="pdk" remote="cm" />
-    <project path="external/jsmn" name="aosp/platform/external/jsmn" groups="pdk" />
-    <project path="external/jsoncpp" name="aosp/platform/external/jsoncpp" groups="pdk-cw-fs" />
-    <project path="external/kernel-headers" name="aosp/platform/external/kernel-headers" groups="pdk-cw-fs" />
-    <project path="external/koush/Superuser" name="CyanogenMod/Superuser" revision="refs/heads/cm-12.0" />
-    <project path="external/libcap-ng" name="aosp/platform/external/libcap-ng" />
+    <project path="external/jsmn" name="aosp_platform_external_jsmn" groups="pdk" />
+    <project path="external/jsoncpp" name="aosp_platform_external_jsoncpp" groups="pdk-cw-fs" />
+    <project path="external/kernel-headers" name="aosp_platform_external_kernel-headers" groups="pdk-cw-fs" />
+    <project path="external/koush/Superuser" name="CyanogenMod_Superuser" revision="refs/heads/cm-12.0" />
+    <project path="external/libcap-ng" name="aosp_platform_external_libcap-ng" />
     <project path="external/libcxx" name="ubports/android_external_libcxx" remote="ubp" groups="pdk" />
-    <project path="external/libcxxabi" name="aosp/platform/external/libcxxabi" groups="pdk" />
-    <project path="external/libgsm" name="aosp/platform/external/libgsm" groups="pdk" />
-    <project path="external/liblzf" name="aosp/platform/external/liblzf" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
-    <project path="external/libnl" name="aosp/platform/external/libnl" groups="pdk" />
-    <project path="external/libogg" name="aosp/platform/external/libogg" groups="pdk" />
-    <project path="external/libopus" name="aosp/platform/external/libopus" groups="pdk" />
+    <project path="external/libcxxabi" name="aosp_platform_external_libcxxabi" groups="pdk" />
+    <project path="external/libgsm" name="aosp_platform_external_libgsm" groups="pdk" />
+    <project path="external/liblzf" name="android_external_liblzf" groups="pdk" revision="phablet-5.1.1_r5" />
+    <project path="external/libnl" name="aosp_platform_external_libnl" groups="pdk" />
+    <project path="external/libogg" name="aosp_platform_external_libogg" groups="pdk" />
+    <project path="external/libopus" name="aosp_platform_external_libopus" groups="pdk" />
     <project path="external/libnfc-nci" name="android_external_libnfc-nxp" groups="pdk" remote="cm" />
     <project path="external/libnfc-nxp" name="android_external_libnfc-nci" groups="pdk" remote="cm" />
     <project path="external/libpng" name="ubports/android_external_libpng" groups="pdk" remote="ubp" />
     <project path="external/libselinux" name="android_external_libselinux" remote="cm" />
     <project path="external/libsepol" name="android_external_libsepol" groups="pdk" remote="cm" />
-    <project path="external/libunwind" name="aosp/platform/external/libunwind" groups="pdk" />
+    <project path="external/libunwind" name="aosp_platform_external_libunwind" groups="pdk" />
     <project path="external/libvpx" name="android_external_libvpx" groups="pdk" remote="cm" />
     <project path="external/libxml2" name="android_external_libxml2" groups="pdk" remote="cm" />
     <project path="external/lz4" name="android_external_lz4" remote="cm" />
     <project path="external/lzma" name="android_external_lzma" remote="cm" />
-    <project path="external/mdnsresponder" name="aosp/platform/external/mdnsresponder" groups="pdk" />
+    <project path="external/mdnsresponder" name="aosp_platform_external_mdnsresponder" groups="pdk" />
     <project path="external/mksh" name="android_external_mksh" groups="pdk" remote="cm" />
     <project path="external/openssl" name="ubports/android_external_openssl" groups="pdk" remote="ubp" />
     <project path="external/pcre" name="android_external_pcre" groups="pdk-cw-fs" remote="cm" />
-    <project path="external/pigz" name="CyanogenMod/android_external_pigz" revision="refs/heads/cm-12.1" />
-    <project path="external/protobuf" name="aosp/platform/external/protobuf" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
-    <project path="external/qemu" name="aosp/platform/external/qemu" groups="pdk-cw-fs" />
-    <project path="external/qemu-pc-bios" name="aosp/platform/external/qemu-pc-bios" groups="pdk-cw-fs" />
-    <project path="external/safe-iop" name="aosp/platform/external/safe-iop" groups="pdk" />
-    <project path="external/scrypt" name="aosp/platform/external/scrypt" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
+    <project path="external/pigz" name="CyanogenMod_android_external_pigz" revision="refs/heads/cm-12.1" />
+    <project path="external/protobuf" name="aosp_platform_external_protobuf" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
+    <project path="external/qemu" name="aosp_platform_external_qemu" groups="pdk-cw-fs" />
+    <project path="external/qemu-pc-bios" name="aosp_platform_external_qemu-pc-bios" groups="pdk-cw-fs" />
+    <project path="external/safe-iop" name="aosp_platform_external_safe-iop" groups="pdk" />
+    <project path="external/scrypt" name="aosp_platform_external_scrypt" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
     <project path="external/sepolicy" name="ubports/android_external_sepolicy" groups="pdk" remote="ubp" />
-    <project path="external/sfntly" name="aosp/platform/external/sfntly" groups="pdk-cw-fs" />
+    <project path="external/sfntly" name="aosp_platform_external_sfntly" groups="pdk-cw-fs" />
     <project path="external/skia" name="android_external_skia" groups="pdk-cw-fs" remote="cm" />
     <project path="external/sonivox" name="android_external_sonivox" groups="pdk" remote="cm" />
     <project path="external/speex" name="android_external_speex" groups="pdk" remote="cm" />
     <project path="external/sqlite" name="android_external_sqlite" groups="pdk" remote="cm" />
     <project path="external/stagefright-plugins" name="android_external_stagefright-plugins" remote="cm" />
-    <project path="external/stlport" name="aosp/platform/external/stlport" groups="pdk" />
+    <project path="external/stlport" name="aosp_platform_external_stlport" groups="pdk" />
     <project path="external/strace" name="android_external_strace" groups="pdk-cw-fs" remote="cm" />
     <project path="external/libtar" name="android_external_libtar" remote="cm" />
     <project path="external/tinyalsa" name="android_external_tinyalsa" groups="pdk" remote="cm" />
     <project path="external/tinycompress" name="android_external_tinycompress" groups="pdk" remote="cm" />
-    <project path="external/tremolo" name="aosp/platform/external/tremolo" groups="pdk" />
-    <project path="external/webp" name="aosp/platform/external/webp" groups="pdk-cw-fs" />
-    <project path="external/webrtc" name="aosp/platform/external/webrtc" groups="pdk" />
+    <project path="external/tremolo" name="aosp_platform_external_tremolo" groups="pdk" />
+    <project path="external/webp" name="aosp_platform_external_webp" groups="pdk-cw-fs" />
+    <project path="external/webrtc" name="aosp_platform_external_webrtc" groups="pdk" />
     <project path="external/wpa_supplicant_8" name="android_external_wpa_supplicant_8" groups="pdk" remote="cm" />
-    <project path="external/yaffs2" name="aosp/platform/external/yaffs2" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
+    <project path="external/yaffs2" name="aosp_platform_external_yaffs2" groups="pdk" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
     <project path="external/zlib" name="ubports/android_external_zlib" groups="pdk" remote="ubp" />
-    <project path="external/zopfli" name="aosp/platform/external/zopfli" groups="pdk-cw-fs" />
+    <project path="external/zopfli" name="aosp_platform_external_zopfli" groups="pdk-cw-fs" />
 
     <project path="frameworks/av" name="halium/android_frameworks_av" groups="pdk" remote="halium" />
     <project path="frameworks/base" name="ubports/android_frameworks_base" groups="pdk-cw-fs" remote="ubp" />
@@ -170,38 +170,37 @@
     <project path="hardware/ril-caf" name="ubports/android_hardware_ril" groups="pdk" revision="ubp-5.1-caf" remote="ubp" />
     <project path="hardware/ril-fp2" name="ubports/android_hardware_ril" groups="pdk" revision="ubp-5.1-fp2" remote="ubp" />
     <project path="hardware/samsung_slsi/exynos5" name="android_hardware_samsung_slsi_exynos5" groups="exynos5" remote="cm" />
-    <project path="hardware/ti/omap3" name="aosp/platform/hardware/ti/omap3" groups="omap3" />
-    <project path="hardware/ti/omap4-aah" name="aosp/platform/hardware/ti/omap4-aah" groups="omap4-aah" />
+    <project path="hardware/ti/omap3" name="aosp_platform_hardware_ti_omap3" groups="omap3" />
+    <project path="hardware/ti/omap4-aah" name="aosp_platform_hardware_ti_omap4-aah" groups="omap4-aah" />
     <project path="hardware/ti/omap4xxx" name="android_hardware_ti_omap4xxx" groups="omap4" remote="cm" />
 
     <project path="libnativehelper" name="android_libnativehelper" groups="pdk" remote="cm" />
 
-    <project path="prebuilts/clang/linux-x86/3.1" name="aosp/platform/prebuilts/clang/linux-x86/3.1" groups="pdk,linux" />
-    <project path="prebuilts/clang/linux-x86/3.2" name="aosp/platform/prebuilts/clang/linux-x86/3.2" groups="pdk,linux" />
-    <project path="prebuilts/clang/linux-x86/arm/3.3" name="aosp/platform/prebuilts/clang/linux-x86/arm/3.3" groups="arm,linux,pdk-cw-fs" />
-    <project path="prebuilts/clang/linux-x86/host/3.4" name="aosp/platform/prebuilts/clang/linux-x86/host/3.4" groups="pdk,linux" />
-    <project path="prebuilts/clang/linux-x86/host/3.5" name="aosp/platform/prebuilts/clang/linux-x86/host/3.5" groups="pdk,linux" />
-    <project path="prebuilts/clang/linux-x86/x86/3.3" name="aosp/platform/prebuilts/clang/linux-x86/x86/3.3" groups="linux,pdk-cw-fs,x86" />
-    <project path="prebuilts/devtools" name="aosp/platform/prebuilts/devtools" />
-    <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.8" name="aosp/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.8" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" name="aosp/platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/arm/arm-eabi-4.8" name="aosp/platform/prebuilts/gcc/linux-x86/arm/arm-eabi-4.8" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" name="aosp/platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.6" name="aosp/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.6" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.8" name="aosp/platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.8" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" name="aosp/platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" groups="linux" />
-    <project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8" name="aosp/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8" groups="linux,x86" />
-    <project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" name="aosp/platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" groups="linux,x86" />
-    <project path="prebuilts/libs/libedit" name="aosp/platform/prebuilts/libs/libedit" groups="pdk-cw-fs" />
-    <project path="prebuilts/maven_repo/android" name="aosp/platform/prebuilts/maven_repo/android" groups="pdk-cw-fs" />
-    <project path="prebuilts/misc" name="aosp/platform/prebuilts/misc" groups="pdk,tradefed" />
-    <project path="prebuilts/ndk" name="aosp/platform/prebuilts/ndk" groups="pdk" />
-    <project path="prebuilts/python/darwin-x86/2.7.5" name="aosp/platform/prebuilts/python/darwin-x86/2.7.5" groups="darwin" />
-    <project path="prebuilts/python/linux-x86/2.7.5" name="aosp/platform/prebuilts/python/linux-x86/2.7.5" groups="linux" />
-    <project path="prebuilts/qemu-kernel" name="aosp/platform/prebuilts/qemu-kernel" groups="pdk" clone-depth="1" />
-    <project path="prebuilts/tools" name="aosp/platform/prebuilts/tools" groups="pdk,tools" />
+    <project path="prebuilts/clang/linux-x86/3.1" name="aosp_platform_prebuilts_clang_linux-x86_3.1" groups="pdk,linux" />
+    <project path="prebuilts/clang/linux-x86/3.2" name="aosp_platform_prebuilts_clang_linux-x86_3.2" groups="pdk,linux" />
+    <project path="prebuilts/clang/linux-x86/arm/3.3" name="aosp_platform_prebuilts_clang_linux-x86_arm_3.3" groups="arm,linux,pdk-cw-fs" />
+    <project path="prebuilts/clang/linux-x86/host/3.4" name="platform/prebuilts/clang/linux-x86/host/3.4" groups="pdk,linux" remote="aosp" />
+    <project path="prebuilts/clang/linux-x86/host/3.5" name="platform/prebuilts/clang/linux-x86/host/3.5" groups="pdk,linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/clang/linux-x86/x86/3.3" name="aosp_platform_prebuilts_clang_linux-x86_x86_3.3" groups="linux,pdk-cw-fs,x86" />
+    <project path="prebuilts/devtools" name="aosp_platform_prebuilts_devtools" />
+    <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.8" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.8" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" name="platform/prebuilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/arm/arm-eabi-4.8" name="platform/prebuilts/gcc/linux-x86/arm/arm-eabi-4.8" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" name="platform/prebuilts/gcc/linux-x86/arm/arm-linux-androideabi-4.8" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.6" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.6" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.8" name="platform/prebuilts/gcc/linux-x86/host/x86_64-linux-glibc2.11-4.8" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" name="platform/prebuilts/gcc/linux-x86/host/x86_64-w64-mingw32-4.8" groups="linux" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.8" groups="linux,x86" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" name="platform/prebuilts/gcc/linux-x86/x86/x86_64-linux-android-4.9" groups="linux,x86" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/libs/libedit" name="aosp_platform_prebuilts_libs_libedit" groups="pdk-cw-fs" />
+    <project path="prebuilts/maven_repo/android" name="aosp_platform_prebuilts_maven_repo_android" groups="pdk-cw-fs" />
+    <project path="prebuilts/misc" name="aosp_platform_prebuilts_misc" groups="pdk,tradefed" />
+    <project path="prebuilts/ndk" name="platform/prebuilts/ndk" groups="pdk" remote="aosp" revision="refs/tags/android-5.1.1_r5" />
+    <project path="prebuilts/python/linux-x86/2.7.5" name="aosp_platform_prebuilts_python_linux-x86_2.7.5" groups="linux" />
+    <project path="prebuilts/qemu-kernel" name="platform/prebuilts/qemu-kernel" groups="pdk" clone-depth="1" remote="aosp"/>
+    <project path="prebuilts/tools" name="aosp_platform_prebuilts_tools" groups="pdk,tools" />
 
-    <project path="sdk" name="aosp/platform/sdk" groups="pdk-cw-fs" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
+    <project path="sdk" name="aosp_platform_sdk" groups="pdk-cw-fs" revision="refs/heads/personal/w-ondra/phablet-5.1.1_r5" />
 
     <project path="system/core" name="ubports/android_system_core" groups="pdk" remote="ubp" />
     <project path="system/extras" name="ubports/android_system_extras" groups="pdk" remote="ubp" />
@@ -212,7 +211,7 @@
     <project path="system/security" name="android_system_security" groups="pdk" remote="cm" />
     <project path="system/vold" name="ubports/android_system_vold" groups="pdk" remote="ubp" />
 
-    <project path="tools/external/fat32lib" name="aosp/platform/tools/external/fat32lib" groups="tools" />
+    <project path="tools/external/fat32lib" name="aosp_platform_tools_external_fat32lib" groups="tools" />
 
     <project path="vendor/cm" name="ubports/android_vendor_cm" remote="ubp" />
 


### PR DESCRIPTION
code-review.phablet.ubuntu.com has now been closed by
Canonical, so we need to use ubports-android on github
instead.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>