### PR TITLE
default.xml: add platform-api, move droidmedia back to halium directory

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -60,7 +60,6 @@
     <project path="external/connectivity" name="android_external_connectivity" remote="los" />
     <project path="external/dlmalloc" name="platform/external/dlmalloc" groups="pdk" remote="aosp" />
     <project path="external/dng_sdk" name="platform/external/dng_sdk" groups="pdk" remote="aosp" />
-    <project path="external/droidmedia" name="droidmedia" remote="sailfishos" revision="master" />
     <project path="external/e2fsprogs" name="android_external_e2fsprogs" groups="pdk" remote="los" />
     <project path="external/exfat" name="android_external_exfat" remote="los" />
     <project path="external/expat" name="platform/external/expat" groups="pdk" />
@@ -257,7 +256,9 @@
 
     <project path="halium/audioflingerglue" name="Halium/audioflingerglue" remote="hal" />
     <project path="halium/devices" name="Halium/halium-devices" remote="hal" />
+    <project path="halium/droidmedia" name="droidmedia" remote="sailfishos" revision="refs/tags/0.20190805.0" />
     <project path="halium/halium-boot" name="Halium/halium-boot" remote="hal" revision="master" />
     <project path="halium/hybris-boot" name="Halium/hybris-boot" remote="hal" revision="refs/heads/master" />
     <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="refs/heads/halium-7.1" />
+    <project path="halium/platform-api" name="ubports/platform-api" remote="hal" revision="xenial"  />
 </manifest>


### PR DESCRIPTION
this adds:
 * platform-api

move droidmedia back to the halium directory thanks to sailfishos/droidmedia#52
and add a specific revision to droidmedia