### PR TITLE
default: Change aosp revision tag to 7.1.2_r37

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -3,7 +3,7 @@
     <remote name="aosp"
             fetch="https://android.googlesource.com"
             review="android-review.googlesource.com"
-            revision="refs/tags/android-7.1.2_r36" />
+            revision="refs/tags/android-7.1.2_r37" />
 
     <remote name="los"
             fetch="https://github.com/LineageOS"


### PR DESCRIPTION
Since clang seems to be missing revision r36 now
(https://android.googlesource.com/platform/external/clang/+refs)
switch to r37 globally for further repo sync'ing to work.