### PR TITLE
default.xml: Add android_device_common

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -44,6 +44,7 @@
 
     <project path="development" name="android_development" remote="los" />
 
+    <project path="device/common" name="device/common" groups="device" remote="aosp" />
     <project path="device/google/contexthub" name="device/google/contexthub" groups="device,marlin,pdk" remote="aosp" />
     <project path="device/qcom/sepolicy" name="android_device_qcom_sepolicy" groups="qcom" remote="los" />
     <project path="device/qcom/common" name="android_device_qcom_common" groups="qcom" remote="los" />


### PR DESCRIPTION
Add android_device_common which in required by GPS on some targets.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>