### PR TITLE
default: upgrade droidmedia to 0.20191025.0

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -256,7 +256,7 @@
 
     <project path="halium/audioflingerglue" name="Halium/audioflingerglue" remote="hal" />
     <project path="halium/devices" name="Halium/halium-devices" remote="hal" />
-    <project path="halium/droidmedia" name="droidmedia" remote="sailfishos" revision="refs/tags/0.20190828.0" />
+    <project path="halium/droidmedia" name="droidmedia" remote="sailfishos" revision="refs/tags/0.20191025.0" />
     <project path="halium/halium-boot" name="Halium/halium-boot" remote="hal" revision="master" />
     <project path="halium/hybris-boot" name="Halium/hybris-boot" remote="hal" revision="refs/heads/master" />
     <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="refs/heads/halium-7.1" />


### PR DESCRIPTION
Changes from the last version including:
- [droidmedia] Start AudioPolicyService conditionally. MER#1550
- droidmedia: Add MIME type for HEVC.
- droidmedia: Add function to query if codec is supported.

Tested with gst-droid version 0.20190805.0 on Ubuntu Touch.

Change-Id: I30ee964ee040661163df3430ab41209fcd32f3b2