### PR TITLE
default.xml: Add new remote for TheMuppets GitLab

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -19,6 +19,10 @@
             fetch="https://github.com/TheMuppets"
             revision="refs/heads/cm-14.1" />
 
+    <remote name="them2"
+            fetch="https://gitlab.com/The-Muppets"
+            revision="refs/heads/cm-14.1" />
+    
     <remote name="sailfishos"
             fetch="https://github.com/sailfishos" />
 


### PR DESCRIPTION
Seems the removed Xiaomi repos from GitHub are still available on GitLab, so lets add the remote for easier referencing in halium-devices.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>