### PR TITLE
default: upgrade droidmedia to 0.20200424.0

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -261,7 +261,7 @@
 
     <project path="halium/audioflingerglue" name="Halium/audioflingerglue" remote="hal" />
     <project path="halium/devices" name="Halium/halium-devices" remote="hal" />
-    <project path="halium/droidmedia" name="droidmedia" remote="sailfishos" revision="refs/tags/0.20191025.0" />
+    <project path="halium/droidmedia" name="droidmedia" remote="sailfishos" revision="refs/tags/0.20200424.0" />
     <project path="halium/halium-boot" name="Halium/halium-boot" remote="hal" revision="master" />
     <project path="halium/hybris-boot" name="Halium/hybris-boot" remote="hal" revision="refs/heads/master" />
     <project path="halium/libhybris" name="Halium/libhybris" remote="hal" revision="refs/heads/halium-7.1" />


### PR DESCRIPTION
Changes since the last update includes:
- Fix an unsafe access to a buffer queue in media codec.
- Prevent a deadlock on codec destruction.
- Cache and re-use queue DroidMediaBuffer instances.

This version introduces an API-breaking change. Update may have to be
co-ordinated between projects using droidmedia via gst-droid.

- Ubuntu Touch (me, although it's not in the main image yet)
- Debian-PM (@JBBgameich, I'll prepare the MRs)
- Plasma Mobile reference distribution (@bhush9)
- LuneOS?

