### PR TITLE
Add unicode and minikin

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -138,6 +138,7 @@
     <project path="external/tinycompress" name="android_external_tinycompress" groups="pdk" remote="los" />
     <project path="external/toybox" name="android_external_toybox" groups="pdk" remote="los" />
     <project path="external/tremolo" name="platform/external/tremolo" groups="pdk" />
+    <project path="external/unicode" name="platform/external/unicode" groups="pdk" remote="aosp"/>
     <project path="external/vulkan-validation-layers" name="platform/external/vulkan-validation-layers" remote="aosp" />
     <project path="external/webp" name="platform/external/webp" groups="pdk-cw-fs" />
     <project path="external/webrtc" name="platform/external/webrtc" groups="pdk" />
@@ -149,6 +150,7 @@
     <project path="frameworks/base" name="Halium/android_frameworks_base" groups="pdk-cw-fs" remote="hal" />
     <project path="frameworks/compile/libbcc" name="platform/frameworks/compile/libbcc" groups="pdk" remote="aosp" />
     <project path="frameworks/compile/slang" name="platform/frameworks/compile/slang" groups="pdk" remote="aosp" />
+    <project path="frameworks/minikin" name="platform/frameworks/minikin" groups="pdk" remote="aosp"/>
     <project path="frameworks/native" name="Halium/android_frameworks_native" groups="pdk" remote="hal" />
     <project path="frameworks/rs" name="platform/frameworks/rs" groups="pdk" remote="aosp" />
 


### PR DESCRIPTION
These libraries are sometimes needed by vendor blobs, like the camera
driver for tissot.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>