### PR TITLE
Fix hardware/qcom/audio remote address

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -180,16 +180,16 @@
     <project path="hardware/libhardware" name="Halium/android_hardware_libhardware" groups="pdk" remote="hal" />
     <project path="hardware/libhardware_legacy" name="Halium/android_hardware_libhardware_legacy" groups="pdk" remote="hal" />
     <project path="hardware/marvell/bt" name="platform/hardware/marvell/bt" groups="marvell_bt" remote="aosp" />
-    <project path="hardware/qcom/audio/default" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1" remote="hal" />
-    <project path="hardware/qcom/audio-caf/apq8084" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8084" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8916" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8916" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8937" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8937" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8952" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8952" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8960" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8960" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8974" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8974" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8994" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8994" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8996" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8996" remote="hal" />
-    <project path="hardware/qcom/audio-caf/msm8998" name="android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8998" remote="hal" />
+    <project path="hardware/qcom/audio/default" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1" remote="hal" />
+    <project path="hardware/qcom/audio-caf/apq8084" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8084" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8916" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8916" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8937" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8937" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8952" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8952" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8960" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8960" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8974" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8974" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8994" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8994" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8996" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8996" remote="hal" />
+    <project path="hardware/qcom/audio-caf/msm8998" name="halium/android_hardware_qcom_audio" groups="qcom,qcom_audio" revision="cm-14.1-caf-8998" remote="hal" />
     <project path="hardware/qcom/bootctrl" name="android_hardware_qcom_bootctrl" groups="pdk" remote="los" />
     <project path="hardware/qcom/bt" name="android_hardware_qcom_bt" groups="qcom" remote="los" />
     <project path="hardware/qcom/bt-caf" name="android_hardware_qcom_bt" groups="qcom" revision="cm-14.1-caf" remote="los" />


### PR DESCRIPTION
Even if the remote is `hal` the `halium/` path should be specified.
From the doc:

> hal | Halium (link to GitHub root for legacy reasons), http://github.com



