### PR TITLE
default.xml: Remove hybris-boot

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -23,7 +23,6 @@
 
   <!-- Hybris repos -->
   <project path="hybris-patches" name="Halium/hybris-patches" revision="halium-9.0" />
-  <project path="hybris/hybris-boot" name="mer-hybris/hybris-boot" revision="master" />
   <project path="hybris/mer-kernel-check" name="mer-hybris/mer-kernel-check" revision="master" />
   <project path="external/droidmedia" name="sailfishos/droidmedia" revision="master" />
   <project path="external/audioflingerglue" name="mer-hybris/audioflingerglue" revision="master" />


### PR DESCRIPTION
Since it's only used by Mer/SFOS which doesn't support Halium.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>