### PR TITLE
(Halium) Add halium/stub_netd into the manifest

### DIFF
--- a/snippets/halium.xml
+++ b/snippets/halium.xml
@@ -9,4 +9,5 @@
   <project path="vendor/halium/droidmedia" name="Halium/droidmedia" revision="halium-10.0" />
   <project path="vendor/halium/libhybris" name="Halium/libhybris" revision="halium-10.0" />
   <project path="vendor/halium/platform-api" name="ubports/platform-api" revision="xenial_-_android9" />
+  <project path="vendor/halium/stub_netd" name="Halium/stub_netd" revision="halium-9.0" />
 </manifest>


### PR DESCRIPTION
@NotKit As discussed, adding stub_netd into the halium-10 manifest. Hoping this is needed for bringing up mobile data in halium-10 similar to halium-9.

I tried compiling it locally in halium-10, it gets compiled fine. Haven't tested running it on any device yet. 