### PR TITLE
snippets: ubports: track bootable/recovery and external/gpg

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -37,7 +37,9 @@
   </project>
   <project path="art" name="LineageOS/android_art" groups="pdk" />
   <project path="bionic" name="LineageOS/android_bionic" groups="pdk" />
+<!--
   <project path="bootable/recovery" name="LineageOS/android_bootable_recovery" groups="pdk" />
+-->
   <project path="cts" name="platform/cts" groups="cts,pdk-cw-fs,pdk-fs" remote="aosp" />
   <project path="dalvik" name="platform/dalvik" groups="pdk-cw-fs,pdk-fs" remote="aosp" />
   <project path="developers/build" name="platform/developers/build" groups="developers,pdk" remote="aosp" />

--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-10.0" />
+  <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+</manifest>


### PR DESCRIPTION
Use the ubports recovery instead of the straight lineage-17.1 fork
and add external/gpg to get a static gpg binary, which is used
by the recovery to verify system updates.

Change-Id: I845a2f91d75581eeb55d4e956ee6ebf6873ac5ab
Signed-off-by: Alexander Martinz <alex@amartinz.at>