### PR TITLE
default: Switch platform-api to correct branch

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -34,7 +34,7 @@
   <project path="halium/devices" name="Halium/halium-devices" revision="halium-9.0" />
   <project path="halium/halium-boot" name="Halium/halium-boot" revision="halium-9.0" />
   <project path="halium/libhybris" name="Halium/libhybris" revision="halium-9.0" />
-  <project path="halium/platform-api" name="ubports/platform-api" revision="xenial_-_edge_-_android8"  />
+  <project path="halium/platform-api" name="ubports/platform-api" revision="xenial_-_android9"  />
   <project path="halium/stub_netd" name="Halium/stub_netd" revision="halium-9.0" />
 
   <!-- AOSP Projects -->


### PR DESCRIPTION
xenial_-_android9 is the official branch name, use it.