### PR TITLE
Change to UBports recovery

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -34,7 +34,7 @@
 
     <project path="bionic" name="Halium/android_bionic" groups="pdk" remote="hal" />
 
-    <project path="bootable/recovery" name="ubports/halium_bootable_recovery" groups="pdk" revision="halium-7.1" />
+    <project path="bootable/recovery" name="ubports/halium_bootable_recovery" groups="pdk" remote="hal" />
 
     <project path="build" name="Halium/android_build" groups="pdk,tradefed" remote="hal" >
         <copyfile src="core/root.mk" dest="Makefile" />

--- a/default.xml
+++ b/default.xml
@@ -34,7 +34,7 @@
 
     <project path="bionic" name="Halium/android_bionic" groups="pdk" remote="hal" />
 
-    <project path="bootable/recovery" name="ubports/halium_bootable_recovery" groups="pdk" remote="hal" />
+    <project path="bootable/recovery" name="ubports/android_bootable_recovery" groups="pdk" remote="hal" />
 
     <project path="build" name="Halium/android_build" groups="pdk,tradefed" remote="hal" >
         <copyfile src="core/root.mk" dest="Makefile" />

--- a/default.xml
+++ b/default.xml
@@ -34,7 +34,7 @@
 
     <project path="bionic" name="Halium/android_bionic" groups="pdk" remote="hal" />
 
-    <project path="bootable/recovery" name="android_bootable_recovery" groups="pdk" remote="los" />
+    <project path="bootable/recovery" name="ubports/halium_bootable_recovery" groups="pdk" revision="halium-7.1" />
 
     <project path="build" name="Halium/android_build" groups="pdk,tradefed" remote="hal" >
         <copyfile src="core/root.mk" dest="Makefile" />


### PR DESCRIPTION
As we see from several manifests the exchange of the LOS recovery leads to old recoveries being used, breaking later functionality and even creating issues with repo sync.

Use UBports recovery also as a default like in other Halium versions. Projects that used the LOS recovery might want to override this.

And here again we can see that unfortunately Halium is (was never) distro-agnostic.