### PR TITLE
Pin droidmedia to 0.20211101.0

### DIFF
--- a/snippets/halium.xml
+++ b/snippets/halium.xml
@@ -11,7 +11,7 @@
   </project>
   <project path="vendor/halium/audioflingerglue" name="Halium/audioflingerglue" revision="master" />
   <project path="vendor/halium/biometryd" name="ubports/core/biometryd" revision="ubports/xenial_-_android9" remote="gitlab" />
-  <project path="vendor/halium/droidmedia" name="sailfishos/droidmedia" revision="4e80b83c04982f09659c7f925f142127727a9b71" />
+  <project path="vendor/halium/droidmedia" name="sailfishos/droidmedia" revision="0.20211101.0" />
   <project path="vendor/halium/hardware" name="Halium/android_vendor_halium_hardware" revision="halium-10.0" />
   <project path="vendor/halium/libhybris" name="Halium/libhybris" revision="halium-11.0" />
   <project path="vendor/halium/manifest" name="Halium/android" revision="halium-11.0" />


### PR DESCRIPTION
In SailfishOS, gst-droid is built against droidmedia-devel which is provided by the adaptation-common repository.

In the current (4.4) release of Sailfish, droidmedia is expected to be 0.20211101.0.  Because on Halium, droidmedia is provided by the halium rootfs, the version must match the version in the current release because changes in the headers used to build gst-droid may result in crashes if there is a mismatch.

I would like to keep the version used in Halium in line with the current released SailfishOS version to minimise problems.

I dont think there are currently any other users of droidmedia and gst-droid so this should have minimal impacts.