### PR TITLE
snippets: ubports: track bootable/recovery and external/gpg

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -45,7 +45,9 @@
   </project>
   <project path="art" name="platform/art" groups="pdk" remote="aosp" />
   <project path="bionic" name="LineageOS/android_bionic" groups="pdk" />
+<!--
   <project path="bootable/recovery" name="LineageOS/android_bootable_recovery" groups="pdk" />
+-->
   <project path="bootable/libbootloader" name="platform/bootable/libbootloader" groups="vts,pdk" remote="aosp" />
   <project path="compatibility/cdd" name="platform/compatibility/cdd" groups="pdk" remote="aosp" />
   <project path="cts" name="platform/cts" groups="cts,pdk-cw-fs,pdk-fs" remote="aosp" />
@@ -1051,6 +1053,7 @@
   <include name="snippets/lineage.xml" />
   <include name="snippets/pixel.xml" />
   <include name="snippets/halium.xml" />
+  <include name="snippets/ubports.xml" />
 
   <repo-hooks in-project="platform/tools/repohooks" enabled-list="pre-upload" />
 </manifest>

--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-12.0" />
+  <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+</manifest>


### PR DESCRIPTION
Use [the ubports recovery](https://github.com/ubports/halium_bootable_recovery/tree/halium-12.0) (~~`halium-12.0` branch to be made still!~~) instead of the straight [`lineage-19.1` fork](https://github.com/LineageOS/android_bootable_recovery/tree/lineage-19.1) and add [`external/gpg`](https://github.com/ubports/android_external_gpg/tree/halium-10.0) to get a static `gpg` binary, which is used by the recovery to verify system updates.