### PR TITLE
[halium-14.0] snippets: ubports: track bootable/recovery and external/gpg

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1270,4 +1270,5 @@
 
   <include name="snippets/lineage.xml" />
   <include name="snippets/halium.xml" />
+  <include name="snippets/ubports.xml" />
 </manifest>

--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remove-project name="LineageOS/android_bootable_recovery" />
+  <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-14.0" />
+  <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+</manifest>


### PR DESCRIPTION
Drafting for now since FastbootD at least is broken on the LineageOS recovery base itself (`Enter fastboot` option just kills `adb` and freezes rendering, looking into this) which I can confirm on both a newer Android 14 native device and 12/13 one.

~~ADB also refuses to give a `root` user shell despite `ro.debuggable=1` & `userdebug` build type..~~ Seemingly fixed with https://github.com/JamiKettunen/halium_bootable_recovery/commit/9020171

Later someone with permissions would have to import https://github.com/JamiKettunen/halium_bootable_recovery/tree/halium-14.0 into https://github.com/UBports/halium_bootable_recovery