### PR TITLE
snippets: ubports: add external/lvm2 for recovery builds

### DIFF
--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -2,4 +2,5 @@
 <manifest>
   <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-13.0" />
   <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+  <project path="external/lvm2" name="Halium/lvm2" revision="halium-13.0" />
 </manifest>


### PR DESCRIPTION
See https://github.com/ubports/halium_bootable_recovery/pull/45