### PR TITLE
[halium-14.0] snippets: ubports: add external/lvm2 for recovery builds

### DIFF
--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -3,4 +3,5 @@
   <remove-project name="LineageOS/android_bootable_recovery" />
   <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-14.0" />
   <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+  <project path="external/lvm2" name="Halium/lvm2" revision="halium-13.0" />
 </manifest>


### PR DESCRIPTION
Forward-port of #100 as the recovery side is already sorted: https://github.com/ubports/halium_bootable_recovery/commits/halium-14.0/. Builds with e.g. `pvresize` present in `adb shell` and on Volla Phone Plinius delta OTA still works