### PR TITLE
halium: switch to halium-13.0 branch of libhybris fork

### DIFF
--- a/snippets/halium.xml
+++ b/snippets/halium.xml
@@ -13,7 +13,7 @@
   <project path="vendor/halium/biometryd" name="ubports/development/core/biometryd" revision="main" remote="gitlab" />
   <project path="vendor/halium/droidmedia" name="Halium/droidmedia" revision="halium-13.0" />
   <project path="vendor/halium/hardware" name="Halium/android_vendor_halium_hardware" revision="halium-13.0" />
-  <project path="vendor/halium/libhybris" name="Halium/libhybris" revision="halium-11.0" />
+  <project path="vendor/halium/libhybris" name="Halium/libhybris" revision="halium-13.0" />
   <project path="vendor/halium/manifest" name="Halium/android" revision="halium-13.0" />
   <project path="vendor/halium/platform-api" name="ubports/development/core/platform-api" revision="main" remote="gitlab" />
   <project path="vendor/halium/selinux_stubs" name="Halium/android_external_selinux_stubs" revision="halium-13.0" />


### PR DESCRIPTION
Can be moved back once compat/hwc2 changes for AIDL are tested.

(cherry picked from commit b3bc38893a6d7de69c8e024e4cf79e9c9cfcee3c)