### PR TITLE
[halium-14.0] snippets/halium: switch platform-api to personal/notkit/aidl-gnss branch

### DIFF
--- a/snippets/halium.xml
+++ b/snippets/halium.xml
@@ -15,7 +15,7 @@
   <project path="vendor/halium/hardware" name="Halium/android_vendor_halium_hardware" revision="halium-14.0" />
   <project path="vendor/halium/libhybris" name="Halium/libhybris" revision="halium-13.0" />
   <project path="vendor/halium/manifest" name="Halium/android" revision="halium-14.0" />
-  <!-- <project path="vendor/halium/platform-api" name="ubports/development/core/platform-api" revision="main" remote="gitlab" /> -->
+  <project path="vendor/halium/platform-api" name="ubports/development/core/platform-api" revision="personal/notkit/aidl-gnss" remote="gitlab" />
   <project path="vendor/halium/selinux_stubs" name="Halium/android_external_selinux_stubs" revision="halium-14.0" />
   <project path="vendor/halium/stub_netd" name="Halium/stub_netd" revision="halium-11.0" />
   <project path="external/libarchive" name="Halium/halium_external_libarchive" revision="halium" />


### PR DESCRIPTION
To have GPS functional on Halium 14; should be switched to `main` after review and testing on older version etc.