### PR TITLE
[halium-14.0] snippets/halium: drop broken stub_netd

### DIFF
--- a/snippets/halium.xml
+++ b/snippets/halium.xml
@@ -17,6 +17,5 @@
   <project path="vendor/halium/manifest" name="Halium/android" revision="halium-14.0" />
   <project path="vendor/halium/platform-api" name="ubports/development/core/platform-api" revision="personal/notkit/aidl-gnss" remote="gitlab" />
   <project path="vendor/halium/selinux_stubs" name="Halium/android_external_selinux_stubs" revision="halium-14.0" />
-  <project path="vendor/halium/stub_netd" name="Halium/stub_netd" revision="halium-11.0" />
   <project path="external/libarchive" name="Halium/halium_external_libarchive" revision="halium" />
 </manifest>


### PR DESCRIPTION
Just tries to and fails to start every 5 seconds as seen in logcat:
```
04-28 11:37:38.986  1876  1876 I android.system.net.netd@1.1-service-stub: Netd HAL Service Stub 1.1 starting...
04-28 11:37:38.986    35    35 I hwservicemanager: getTransport: Cannot find entry android.system.net.netd@1.1::INetd/default in either framework or device VINTF manifest.
04-28 11:37:38.987  1876  1876 E HidlServiceManagement: Service android.system.net.netd@1.1::INetd/default must be in VINTF manifest in order to register/get.
04-28 11:37:38.987  1876  1876 E android.system.net.netd@1.1-service-stub: Could not register service for Netd HAL (-2147483648)
04-28 11:37:38.987  1876  1876 E android.system.net.netd@1.1-service-stub: Netd Service is shutting down.
```
Also appears irrelevant for working cellular data/WLAN on Volla Phone Plinius at least