### PR TITLE
[halium-16.0] snippets: ubports: track bootable/recovery and external/{gpg,lvm2}

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -1048,4 +1048,5 @@
 
   <include name="snippets/lineage.xml" />
   <include name="snippets/halium.xml" />
+  <include name="snippets/ubports.xml" />
 </manifest>

--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <manifest>
   <remove-project name="LineageOS/android_bootable_recovery" />
-  <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-16.0" />
-  <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+  <project path="bootable/recovery" name="JamiKettunen/halium_bootable_recovery" revision="halium-16.0" />
+  <project path="external/gpg" name="JamiKettunen/android_external_gpg" revision="halium-16.0" />
   <project path="external/lvm2" name="Halium/lvm2" revision="halium-13.0" />
 </manifest>

--- a/snippets/ubports.xml
+++ b/snippets/ubports.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<manifest>
+  <remove-project name="LineageOS/android_bootable_recovery" />
+  <project path="bootable/recovery" name="ubports/halium_bootable_recovery" revision="halium-16.0" />
+  <project path="external/gpg" name="ubports/android_external_gpg" revision="halium-10.0" />
+  <project path="external/lvm2" name="Halium/lvm2" revision="halium-13.0" />
+</manifest>


### PR DESCRIPTION
Compiles with https://github.com/JamiKettunen/android_external_gpg/tree/halium-16.0 which perhaps should be imported/merged too depending on how the changes want to be done; took the liberty to also get proper diff to upstream tarball and bumped it from v1.4.13 (late 2012) -> v1.4.23 (mid 2018) so it's at least on the latest legacy branch version

OTAs don't currently work due to `busybox` not being installed:
```
/system/bin/system-image-upgrader[576]: busybox: inaccessible or not found
```

Kernel versions <4.14 will also need a revert of https://github.com/LineageOS/android_bionic/commit/10893f6 or preferably some cleaner solution:
```
[    2.337717]  (5)[1:init]arc4random data MADV_WIPEONFORK failed: Invalid argument
[    2.337826]  (5)[1:init]libc: arc4random data MADV_WIPEONFORK failed: Invalid argument
[    2.338081] -(5)[1:init]Kernel panic - not syncing: Attempted to kill init! exitcode=0x00007f00
```

Kernel [v4.4.153 OnePlus 5](https://gitlab.com/ubports/porting/community-ports/android9/oneplus-5/android_kernel_oneplus_msm8998) boots while [v4.4.146 Volla Phone](https://gitlab.com/ubports/porting/reference-device-ports/android9/volla-phone/android_kernel_volla_mt6763) doesn't (and doesn't seem like a kernel panic either); similar was fixed previously with https://github.com/Halium/hybris-patches/commit/eab63d2 but should be redundant with https://github.com/Halium/hybris-patches/blob/halium-16.0/system/core/0023-halium-make-cgroup-setup-failures-non-fatal-in-conta.patch

We could also check if the generated resources should be updated with something like:
```sh
for dpi in mdpi hdpi xhdpi xxhdpi xxxhdpi; do
  sed -i '/TARGET_RECOVERY_DENSITY/d' device/halium/halium_arm64/BoardConfig.mk
  echo "TARGET_RECOVERY_DENSITY := $dpi" >> device/halium/halium_arm64/BoardConfig.mk
  make recoveryramdisk -j$(nproc)
  diff -r bootable/recovery/res-$dpi/images/ out/target/product/halium_arm64/recovery/root/res/images/
done
```

Once finalized https://github.com/JamiKettunen/halium_bootable_recovery/tree/halium-16.0 should be imported to https://github.com/ubports/halium_bootable_recovery before merging this